### PR TITLE
Removed material-icons dependency and commented out code

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "jquery": "~2.1.4",
     "raphael": "~2.1.4",
-    "jquery.raphael.spinner": "git://github.com/hunterae/jquery.raphael.spinner.git",
-    "material-icons": "~0.1.0"
+    "jquery.raphael.spinner": "git://github.com/hunterae/jquery.raphael.spinner.git"
   }
 }

--- a/europe-pmcentralizer.js
+++ b/europe-pmcentralizer.js
@@ -25,11 +25,6 @@ function articalLinks(pmcArticle, type, settings){
     onclick: "trackResourceLink('PubMed','http://www.ncbi.nlm.nih.gov/pubmed/"+pmcArticle.pmid+"'); return false;"
   }).text('Pubmed'));
   links.append('&nbsp;');
-  /*var toggle = $('<i>').attr({
-    'class': 'icon-'+type,
-    'id': pmcArticle.pmid+'-toggle-'+type
-  });
-  */
   var toggle = $('<i>').attr({
     id: pmcArticle.pmid+'-toggle-'+type,
     class: 'material-icons'


### PR DESCRIPTION
material-icons is not needed as we should use the css from google itself (https://fonts.googleapis.com/icon?family=Material+Icons) or by downloading the material icons as described in the doc (https://www.google.com/design/icons/).
