### PR TITLE
Add article div for the failed result

### DIFF
--- a/europe-pmcentralizer.js
+++ b/europe-pmcentralizer.js
@@ -137,7 +137,7 @@ function getPMCReferences(settings){
     
     jqxhr.fail(function() {
       $(pubmed).find(".pmcspinner").remove();
-      var links = $('<div>').attr('class', 'links');
+      var articleDiv = $('<div>').attr('class', 'article');
       var ul = $('<ul>').css({
         'list-style-type' : 'none',
         'padding-left'    : 0,
@@ -157,7 +157,8 @@ function getPMCReferences(settings){
         }).text('Pubmed'));
         li.appendTo(ul);
       };
-      ul.appendTo(pubmed);
+      ul.appendTo(articleDiv);
+      articleDiv.appendTo(pubmed);
     });
     
   });


### PR DESCRIPTION
Since users may have added css rules to .article is is only right for the failed results to have the div so that the style is maintained.
